### PR TITLE
optimize enqueue operation by using tail pointer instead of traversing the queue

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -59,25 +59,24 @@ FMQ_Queue *FMQ_Queue_new(const u_int16_t msg_size, const int8_t log_level)
 
 void FMQ_Queue_enqueue(FMQ_Queue *queue, void *data)
 {
-    FMQ_QNode *tmpHeadNode = queue->head;
     FMQ_QNode *node = FMQ_QNode_new(data);
     queue->size += 1;
+
     if (queue->head == NULL)
     {
         queue->head = node;
         queue->tail = node;
-        return;
+    }
+    else
+    {
+        queue->tail->next = node;
+        queue->tail = node;
     }
 
-    while (tmpHeadNode->next != NULL)
-    {
-        tmpHeadNode = tmpHeadNode->next;
-    }
-    tmpHeadNode->next = node;
-    queue->tail = node;
     FMQ_LOGGER(queue->log_level, "{queue}: Queue successfully updated\n"
         "{queue}: Queue size: %d\n", queue->size);
 }
+
 
 FMQ_QNode *FMQ_Queue_dequeue(FMQ_Queue *queue)
 {


### PR DESCRIPTION
This PR optimizes the `FMQ_Queue_enqueue` function. 
Instead of traversing the queue to find the last node, it now uses the tail pointer to add new items, reducing the time complexity from O(N) to O(1).

Additionally, the function is updated to call the log macro before returning, removing the early return statement in case the head of the queue is `NULL`.